### PR TITLE
blue-common: Cleanup the device tree sources

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -31,11 +31,20 @@ TARGET_BOARD_PLATFORM := msm8960
 TARGET_BOOTLOADER_BOARD_NAME := MSM8960
 
 # Kernel information
-BOARD_KERNEL_CMDLINE := # This is ignored by sony's bootloader
+BOARD_KERNEL_CMDLINE := # Ignored, see cmdline.txt
 BOARD_KERNEL_BASE := 0x80200000
 BOARD_RECOVERY_BASE := 0x80200000
 BOARD_KERNEL_PAGESIZE := 2048
 BOARD_MKBOOTIMG_ARGS := --ramdisk_offset 0x01700000
+
+# Partitions informations
+BOARD_BOOTIMAGE_PARTITION_SIZE := 0x01400000
+BOARD_RECOVERYIMAGE_PARTITION_SIZE := 0x01400000
+BOARD_SYSTEMIMAGE_PARTITION_SIZE := 1056964608
+BOARD_USERDATAIMAGE_PARTITION_SIZE := 2147483648
+
+# Partition settings
+BOARD_FLASH_BLOCK_SIZE := 131072
 
 # Bionic
 MALLOC_IMPL := dlmalloc
@@ -55,9 +64,6 @@ TARGET_PROVIDES_CAMERA_HAL := true
 # Display HAL
 TARGET_USES_ION := true
 TARGET_USES_C2D_COMPOSITION := true
-
-# Font expansion
-EXTENDED_FONT_FOOTPRINT := true
 
 # Lights HAL
 TARGET_PROVIDES_LIBLIGHT := true
@@ -108,18 +114,15 @@ BOARD_RIL_CLASS := ../../../device/sony/blue-common/ril/
 # Needed for blobs
 TARGET_RELEASE_CPPFLAGS += -DNEEDS_VECTORIMPL_SYMBOLS
 
-# Vold
-TARGET_USE_CUSTOM_LUN_FILE_PATH := /sys/devices/platform/msm_hsusb/gadget/lun%d/file
-
 # Custom boot
 BOARD_CUSTOM_BOOTIMG := true
 BOARD_CUSTOM_BOOTIMG_MK := device/sony/blue-common/custombootimg.mk
 TARGET_RELEASETOOLS_EXTENSIONS := device/sony/blue-common
 
 # Recovery
-TARGET_RECOVERY_PIXEL_FORMAT := "RGBX_8888"
-BOARD_USE_CUSTOM_RECOVERY_FONT := \"roboto_15x24.h\"
+BOARD_HAS_NO_SELECT_BUTTON := true
 TARGET_RECOVERY_FSTAB := device/sony/blue-common/rootdir/fstab.qcom
+TARGET_USERIMAGES_USE_EXT4 := true
 
 # Audio
 AUDIO_FEATURE_ENABLED_INCALL_MUSIC := false

--- a/common.mk
+++ b/common.mk
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DEVICE_PACKAGE_OVERLAYS += $(COMMON_PATH)/overlay
+
 COMMON_PATH := device/sony/blue-common
 
-DEVICE_PACKAGE_OVERLAYS += $(COMMON_PATH)/overlay
+$(call inherit-product, frameworks/native/build/phone-xhdpi-1024-dalvik-heap.mk)
 
 # Permissions
 PRODUCT_COPY_FILES += \
@@ -32,7 +34,8 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.usb.host.xml:system/etc/permissions/android.hardware.usb.host.xml \
     frameworks/native/data/etc/android.hardware.wifi.direct.xml:system/etc/permissions/android.hardware.wifi.direct.xml \
     frameworks/native/data/etc/android.hardware.wifi.xml:system/etc/permissions/android.hardware.wifi.xml \
-    frameworks/native/data/etc/handheld_core_hardware.xml:system/etc/permissions/handheld_core_hardware.xml
+    frameworks/native/data/etc/handheld_core_hardware.xml:system/etc/permissions/handheld_core_hardware.xml \
+    frameworks/native/data/etc/android.hardware.telephony.gsm.xml:system/etc/permissions/android.hardware.telephony.gsm.xml
 
 # Media profile
 PRODUCT_COPY_FILES += \
@@ -258,6 +261,14 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.disableWifiApFirmwareReload=true \
     wifi.interface=wlan0 \
     wlan.driver.ath=0
+
+# Graphics
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.sf.lcd_density=320
+
+# Storage
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.vold.primary_physical=1
 
 PRODUCT_PACKAGES += \
     libQWiFiSoftApCfg \


### PR DESCRIPTION
 * Move common blue parameters to blue-common
 * Minimize the amount of duplicated code in devices
 * Rename the blue.mk to common.mk, used by device.mk files
 * Delete useless config flags

Change-Id: I65b3731eb11f6f160fea257b530151f7997bbd7b
Signed-off-by: AdrianDC <radian.dc@gmail.com>