### PR TITLE
blue-common: release: Detect MultiROM flashing in the unification checks

### DIFF
--- a/releasetools/unify_userdata/main.sh
+++ b/releasetools/unify_userdata/main.sh
@@ -33,6 +33,16 @@ if [ -e ${flag_partitions_changed} ]; then
 fi;
 
 #------------------------------------------------------------
+# Detect a MultiROM installation and ignore the unification
+if [ -e /tmp/mrom_fakebootpart ]; then
+  ui_print ' ';
+  ui_print 'Installation as a MultiROM detected';
+  ui_print 'Unified partitions layout validated';
+  ui_print ' ';
+  exit ${exec_success};
+fi;
+
+#------------------------------------------------------------
 # Handle the usage of an old dangerous TWRP version
 if [ -e /twres/twrp ] || [ -e /res/twrp ]; then
   if [ $(prop_default_date_timestamp) -lt ${twrp_timestamp_safe} ]; then


### PR DESCRIPTION
 * When flashing as a MultiROM, the unification path should not be executed,
    even on a device that was unified before, the checks for the physical flag
    that performs an umount / mount of the real data partition breaks
    the install process and the partitions remapping of MultiROM

 * Avoid this by detecting the /tmp/mrom_fakebootpart flag
    that will only exist during a MultiROM instalation

 * Thanks to nkk71 for going through the sources with me
    to figure out the origin of this issue upon installations

Change-Id: Ia8582f558cce4e6ce1be5fb24c748ff6216f5a1d